### PR TITLE
change folder permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Prerequisites:
 ```bash
 $ git clone https://github.com/abba23/spotify-adblock.git
 $ cd spotify-adblock
+$ sudo chmod ugo+rwx spotify-adblock/
 $ make
 ```
 


### PR DESCRIPTION
building using make doesn't work if the folder's permissions aren't set (you get a `error: failed to write` thrown at you)