### PR TITLE
Added tips on working around GPG error on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Spotify adblocker for Linux (macOS untested) that works by wrapping `getaddrinfo
 ### Notes
 * This **does not** work with the snap Spotify package.
 * This **might not** work with the Flatpak Spotify package, depending on your system's shared libraries' versions.
-* On Debian-based distributions (e.g. Ubuntu), the Debian Spotify package can be installed by following the instructions at the bottom of [this page](https://www.spotify.com/us/download/linux/). *(recommended)*
+* On Debian-based distributions (e.g. Ubuntu), the Debian Spotify package can be installed by following the instructions at the bottom of [this page](https://www.spotify.com/us/download/linux/) *(recommended)*. If you encounter a GPG error when running `apt update`, copy the key mentioned in the error message and use it to run `apt-key adv --keyserver keyserver.ubuntu.com --recv-keys <KEY>`.
+
+
 
 ## Build
 Prerequisites:


### PR DESCRIPTION
I had a bit of trouble installing the Debian Spotify on Ubuntu 20.04 due to the keys on https://www.spotify.com/us/download/linux/ being out of date. Took me a bit of digging to find a solution, so I think many Debian-derivative users will benefit from this.