### PR TITLE
Update Makefile to add error message for missing Cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotify-adblock"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["abba23"]
 description = "Adblocker for Spotify"
 edition = "2018"

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,18 @@ CONFIG_PATH = config.toml
 BINARY_TARGET = $(DESTDIR)$(PREFIX)/lib/$(NAME).so
 CONFIG_TARGET = $(DESTDIR)/etc/$(NAME)/config.toml
 
+# Is the prerequisite "cargo" installed?
+PREREQ := $(shell command -v cargo 2> /dev/null)
+
 .PHONY: all
 all: $(BINARY_PATH)
 
 $(BINARY_PATH): src Cargo.toml
 	# cargo build --profile $(PROFILE)
+ifndef PREREQ
+	# Give some useful error message
+	$(error "It appears Rust and/or Cargo is not available please install it")
+endif
 ifeq ($(PROFILE), release)
 	cargo build --release
 else

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Spotify adblocker for Linux (macOS untested) that works by wrapping `getaddrinfo
 
 ## Build
 Prerequisites:
+* Cargo
 * Git
 * Make
 * Rust


### PR DESCRIPTION
A quick, and somewhat hard-coded check to see if `cargo` is available as a command.

If not, exit with an error message to help users understand Cargo (and/or Rust) needs to be installed.

This issue has been reported as number #75, 55, 11 and 5 just to mention a few of them.

---

Also included is a minor update to `Cargo.toml` given the new tag (v1.0.1) a few days ago. And adding of `Cargo` as an explicitly stated prerequisites in the `README.md`.

Feel free to edit anything or simply close/discard this MR. Please note: I have only tested it with Bash on a Ubuntu Linux machine.