### PR TITLE
Add [secure]pubads.g.doubleclick.net to denylist

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -79,5 +79,7 @@ allowlist = [
 denylist = [
     'https://spclient\.wg\.spotify\.com/ads/.*', # ads
     'https://spclient\.wg\.spotify\.com/ad-logic/.*', # ads
+    'https://pubads\.g\.doubleclick\.net/.*', # ads
+    'https://securepubads\.g\.doubleclick\.net/.*', # ads
     'https://spclient\.wg\.spotify\.com/gabo-receiver-service/.*', # tracking
 ]


### PR DESCRIPTION
Not all ads seemed to be be blocked anymore on the apt version of Spotify, adding these domains to the denylist should fix that.