### PR TITLE
Update allowlist to fix discord presence

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,7 +48,7 @@ allowlist = [
     'xpui\.app\.spotify\.com', # user interface
     'apresolve\.spotify\.com', # access point resolving
     'clienttoken\.spotify\.com', # login
-    '.*dealer\.spotify\.com', # websocket connections
+    '.*dealer.?\.spotify\.com', # websocket connections
     'image-upload.*\.spotify\.com', # image uploading
     'login.*\.spotify\.com', # login
     '.*-spclient\.spotify\.com', # client APIs


### PR DESCRIPTION
The discord presence websocket seems to have changed to use `gew1-dealer2.spotify.com`, which is not in the current allowlist, causing it to not appear on profiles.