### PR TITLE
Updating the documentation for the flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ sudo make install
 #### Flatpak
 ```bash
 $ mkdir -p ~/.spotify-adblock && cp target/release/libspotifyadblock.so ~/.spotify-adblock/spotify-adblock.so
-$ mkdir -p ~/.config/spotify-adblock && cp config.toml ~/.config/spotify-adblock
+$ mkdir -p ~/.var/app/com.spotify.Client/config/spotify-adblock && cp config.toml ~/.var/app/com.spotify.Client/config/spotify-adblock
 $ flatpak override --user --filesystem="~/.spotify-adblock/spotify-adblock.so" --filesystem="~/.config/spotify-adblock/config.toml" com.spotify.Client
 ```
 


### PR DESCRIPTION
I found that the current `flatpak` method for `config.toml` in the [README.md](https://github.com/abba23/spotify-adblock/blob/main/README.md) doesn't work for me, and seems to not work for others. The proper directory seems to be `~/.var/app/com.spotify.Client/config/spotify-adblock`. So here is an update of the [README.md](https://github.com/abba23/spotify-adblock/blob/main/README.md).