### PR TITLE
fixed discord rich presence and connecting between different devices

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,7 +48,7 @@ allowlist = [
     'xpui\.app\.spotify\.com', # user interface
     'apresolve\.spotify\.com', # access point resolving
     'clienttoken\.spotify\.com', # login
-    '.*dealer.?\.spotify\.com', # websocket connections
+    '.*dealer.*\.spotify\.com', # websocket connections
     'image-upload.*\.spotify\.com', # image uploading
     'login.*\.spotify\.com', # login
     '.*-spclient\.spotify\.com', # client APIs


### PR DESCRIPTION
Usually when playing music off a different device, your phone for example, your computer will show whats playing and vice versa; this once again works with this change. 