### PR TITLE
Update Cargo.toml: add license & crate_type Deprecation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ toml = "*"
 
 [lib]
 name = "spotifyadblock"
-crate_type = ["cdylib"]
+crate-type = ["cdylib"]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.2"
 authors = ["abba23"]
 description = "Adblocker for Spotify"
 edition = "2021"
+license = "GPL-3.0-only"
 
 [dependencies]
 lazy_static = "*"


### PR DESCRIPTION
```
+ license = "GPL-3.0-only"

- crate_type = ["cdylib"]
+ crate-type = ["cdylib"]
```
this fixes: 
```
$ cargo deb
warning: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
warning: license field is missing in Cargo.toml
```

